### PR TITLE
Updated required laravel version to 5.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "laravel/framework": "5.1.*"
+        "laravel/framework": "5.*"
     },
     "require-dev": {
     },


### PR DESCRIPTION
Instead of 5.1.* this change enables to use the library in 5.* versions.